### PR TITLE
fix: deleted / hid useless on offer pages

### DIFF
--- a/controllers/OfferController.php
+++ b/controllers/OfferController.php
@@ -230,9 +230,9 @@ class OfferController extends Controller
             $tagsName[] = $tag->name;
         }
 
-        $prestationsIncluses = "A";
-        $prestationsNonIncluses = "B";
-        $accessibilite = "C";
+        $prestationsIncluses = "";
+        $prestationsNonIncluses = "";
+        $accessibilite = "";
 
         $languages = VisitLanguage::findOne(['offer_id' => $id])->language;
         $formattedAddress = $address->number . ' ' . $address->street . ', ' . $address->postal_code . ' ' . $address->city;

--- a/views/offers/detail.php
+++ b/views/offers/detail.php
@@ -233,14 +233,14 @@ if ($status == "Fermé") {
     <aside class="sticky col-span-2 h-fit flex flex-col gap-4 top-navbar-height">
         <div class="map-container">
             <div id="map" class="map"></div>
-            <button class="button gray spaced">
+            <!-- <button class="button gray spaced">
                 Itinéraire
                 <i data-lucide="map"></i>
             </button>
             <button class="button gray spaced">
                 Ouvrir dans Maps
                 <i data-lucide="arrow-up-right"></i>
-            </button>
+            </button> -->
         </div>
 
         <?php if (Application::$app->user?->isProfessional()) { ?>


### PR DESCRIPTION
"Itinéraire" and "Ouvrir sur Google Maps" are now commented in views/offer/detail.php

$prestationsIncluses ; $prestationsNonIncluses ; and $accessibilite in controller/OfferController.php are now void

Don't forget to change those for tests